### PR TITLE
more flexible humus roots settings

### DIFF
--- a/R/fnc_PTF.R
+++ b/R/fnc_PTF.R
@@ -10,13 +10,16 @@
 #'   \item humus - thickness of the humus-layer (repeated \code{nrow} - times. a bit clumsy, but building on existing code it was the most convenient way) \cr LWFB90 has problems if the first row is too thin and creates surface flow if it becomes saturated, which can happen if the humus layer is too thin. So, if humus is <= 2cm, it will be removed, 3 cm will be turned into 4 cm. Anything above is fine.
 #' }
 #' @param PTF_used PTF-options from the \code{LWFBrook90R} - package. Choices are \code{"HYPRES"}, \code{"PTFPUH2"}, or \code{"WESSOLEK"}.
+#' @param limit_humus if \code{ilayer = 0} and \code{infexp = 0}, which is the default setting in \code{\link[LWFBrook90R]{set_paramLWFB90}}, water can only infiltrate in the first layer. If thin humus layers (e.g. 2 cm) are put on top of the first mineral soil layer, there's a risk of creating unrealisic amounts of surface runoff, when the water storage capacity of the thin humus layer can't take the incoming amount of daily rain. Hence, this parameter deletes humus lazers smaller or equal 2 cm, and increases humus layers of 3 cm to 4 cm. Default is \code{T}. If  \code{ilayer} and \code{infexp} are greater than 0, this issue shouldn't occur and this parameter should be set to \code{F}
 #'
 #' @references Hammel, K., & Kennel, M. (2001). Charakterisierung und Analyse der Wasserverfügbarkeit und des Wasserhaushalts von Waldstandorten in Bayern mit dem Simulationsmodell BROOK90. Frank.
 #'
 #' @return Returns a longer data.table that already includes an earlier version of ls.soils. Further processed in \code{\link{fnc_get_soil}}.
 #' @export
 
-fnc_PTF <- function(df, PTF_used){
+fnc_PTF <- function(df,
+                    PTF_used,
+                    limit_humus){
 
   if("humusform" %in% colnames(df)){
     df <- df %>%
@@ -40,9 +43,12 @@ fnc_PTF <- function(df, PTF_used){
   }
 
 
-  # thickness limits to humus layer
-  df$humus <- ifelse(unique(df$humus) <= 0.02, 0,
-                     ifelse(unique(df$humus) <= 0.04, 0.04, unique(df$humus)))
+  if(limit_humus){
+    # thickness limits to humus layer
+    df$humus <- ifelse(unique(df$humus) <= 0.02, 0,
+                       ifelse(unique(df$humus) <= 0.04, 0.04, unique(df$humus)))
+  }
+
 
   #
   if(PTF_used == "HYPRES"){

--- a/man/fnc_PTF.Rd
+++ b/man/fnc_PTF.Rd
@@ -4,7 +4,7 @@
 \alias{fnc_PTF}
 \title{PTF application and humus layer creation}
 \usage{
-fnc_PTF(df, PTF_used)
+fnc_PTF(df, PTF_used, limit_humus)
 }
 \arguments{
 \item{df}{data frame containing information on soil physics in the following columns:
@@ -16,6 +16,8 @@ fnc_PTF(df, PTF_used)
 }}
 
 \item{PTF_used}{PTF-options from the \code{LWFBrook90R} - package. Choices are \code{"HYPRES"}, \code{"PTFPUH2"}, or \code{"WESSOLEK"}.}
+
+\item{limit_humus}{if \code{ilayer = 0} and \code{infexp = 0}, which is the default setting in \code{\link[LWFBrook90R]{set_paramLWFB90}}, water can only infiltrate in the first layer. If thin humus layers (e.g. 2 cm) are put on top of the first mineral soil layer, there's a risk of creating unrealisic amounts of surface runoff, when the water storage capacity of the thin humus layer can't take the incoming amount of daily rain. Hence, this parameter deletes humus lazers smaller or equal 2 cm, and increases humus layers of 3 cm to 4 cm. Default is \code{T}. If  \code{ilayer} and \code{infexp} are greater than 0, this issue shouldn't occur and this parameter should be set to \code{F}}
 }
 \value{
 Returns a longer data.table that already includes an earlier version of ls.soils. Further processed in \code{\link{fnc_get_soil}}.

--- a/man/fnc_get_soil.Rd
+++ b/man/fnc_get_soil.Rd
@@ -8,10 +8,12 @@ fnc_get_soil(
   df.ids,
   soil_option,
   PTF_to_use,
+  BW_or_D = "BW",
   df.soils = NULL,
   limit_MvG = T,
   add_BodenInfo = T,
   incl_GEOLA = T,
+  limit_humus = T,
   parallel_processing = F,
   bze_buffer = 12,
   meta.out = NA,
@@ -60,6 +62,8 @@ If the nFK shall be calculated at some point, this will be done for the first 1m
 \item{add_BodenInfo}{shall further soil info (nFK, PWP, FK, texture ...) be added to the soil-df, default is \code{TRUE}}
 
 \item{incl_GEOLA}{information from the \emph{Geowissenschaftliche Landesaufnahme} will be used to get additional data on soil depth and max root depth. On top of that,  \emph{Standortskartierung} and  \emph{GEOLA} will be used for identifying soil types that will be modelled differently to include the effect of groundwater (Gleye / Auenboeden) or alternating Saturation (Stauwasserboeden). Default is \code{TRUE}}
+
+\item{limit_humus}{will be passed to \code{\link{fnc_PTF}}. See documentation for further information.}
 
 \item{parallel_processing}{the lists of dataframes are processed several times (adding roots, adding nFK information etc.). Default is \code{F} and runs with normal \code{lapply} statements. If many points are modelled, it is advised to set this to \code{T}, to activate parallel processing on several cores (as many as available). A BZE-based testrun with 32 GB RAM and 8 cores revealed a higher performance of parallel processing starting at the threshold of 250 points.}
 

--- a/man/fnc_roots.Rd
+++ b/man/fnc_roots.Rd
@@ -8,7 +8,7 @@ fnc_roots(
   df,
   rootsmethod = "betamodel",
   humus_roots = T,
-  rel_hum_val = NA,
+  rel_hum_val = 0.5,
   ...
 )
 }
@@ -17,9 +17,7 @@ fnc_roots(
 
 \item{rootsmethod}{name of the method for fine roots. Possible options are \code{hartmann},\code{betamodel}, \code{table}, \code{constant}, and \code{linear}. Default is \code{betamodel}.}
 
-\item{humus_roots}{decides whether humus layers get roots too. Default is \code{TRUE}. If \code{FALSE}, humus layer gets a rootden-value of \code{0}. If \code{TRUE} and \code{rel_hum_val = NA}, humus layer gets half the amount of roots as highest soil layer. If \code{rel_hum_val} is a value, humus layer gets this value}
-
-\item{rel_hum_val}{roots in humuslayer as fraction of roots in soil. Default is \code{NA}}
+\item{humus_roots}{roots in humuslayer as fraction of roots in highest mineral soil layer. Default is \code{0.5}}
 
 \item{...}{additional input arguments that are passed on to \code{make_rootden}, see \code{\link[LWFBrook90R]{make_rootden}}.}
 }


### PR DESCRIPTION
makes humus in roots more flexible: 
- reduction optional (if ilayer > 1)
- roots in humus as fraction of upmost mineral soil layer providable
- plus: fnc_get_soil with D-wide applicability